### PR TITLE
RN 0.40+ fix build error duplicate interface definition of class 'RCTBridge' and 'RCTBridgeModule'

### DIFF
--- a/RCTWeChat/RCTWeChat/RCTWeChat.h
+++ b/RCTWeChat/RCTWeChat/RCTWeChat.h
@@ -7,7 +7,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
 #import "WXApi.h"
 
 @interface RCTWeChat : NSObject <RCTBridgeModule, WXApiDelegate>

--- a/RCTWeChat/RCTWeChat/RCTWeChat.m
+++ b/RCTWeChat/RCTWeChat/RCTWeChat.m
@@ -7,7 +7,11 @@
 //
 
 #import "RCTWeChat.h"
+#if __has_include(<React/RCTBridge.h>)
+#import <React/RCTBridge.h>
+#else
 #import "RCTBridge.h"
+#endif
 #import "RCTEventDispatcher.h"
 #import "WXApi.h"
 #import "WXApiObject.h"


### PR DESCRIPTION
in RN 0.40.0, iOS native headers are moved
https://github.com/facebook/react-native/releases/tag/v0.40.0